### PR TITLE
correct timetk installation command with poetry

### DIFF
--- a/docs/getting-started/01_installation.qmd
+++ b/docs/getting-started/01_installation.qmd
@@ -35,7 +35,7 @@ git clone https://github.com/business-science/pytimetk
 Use Poetry to install the package and its dependencies:
 
 ```
-pip install poetry
+poetry install
 ```
 
 or you can create a virtualenv with poetry and install the dependencies


### PR DESCRIPTION
Just removing (surely) a typo in the installation of timetk and dependencies using poetry.
It is currently written: 
`pip install poetry`.

So I've changed it to `poetry install`