### PR TITLE
Pad By Time Grouped - End Behavior #37

### DIFF
--- a/src/timetk/core/pad.py
+++ b/src/timetk/core/pad.py
@@ -12,6 +12,7 @@ def pad_by_time(
     data: pd.DataFrame or pd.core.groupby.generic.DataFrameGroupBy,
     date_column: str,  
     freq: str = 'D',
+    global_group_max: str = 'Y',
 ) -> pd.DataFrame:
     '''
     Make irregular time series regular by padding with missing dates.
@@ -41,7 +42,11 @@ def pad_by_time(
         - QS: quarter start frequency
         - Y: year end frequency
         - YS: year start frequency
+    global_group_max : str, optional
+        The 'global_group_max' parameter allows you to determine the end behavior of padding when using grouped data.  
         
+        - Y: The max date of global population will be used to pad.
+        - N: The max_date will be the max date for the specific group.  
     
     
     Returns
@@ -135,6 +140,9 @@ def pad_by_time(
         groups = df[group_names].drop_duplicates()
         padded_dfs = []
         
+        #uses global max date to pad rather than local.  
+        global_max_date = df[date_column].max()
+
         for idx, group in groups.iterrows():
             mask = (df[group_names] == group).all(axis=1)
             group_df = df[mask]
@@ -143,7 +151,11 @@ def pad_by_time(
             #     freq = get_pandas_frequency(group_df[date_column], force_regular=force_regular)
             
             min_date = group_df[date_column].min()
-            max_date = group_df[date_column].max()
+            if global_group_max == 'Y':
+                max_date = global_max_date
+            if global_group_max == 'N':
+                max_date = group_df[date_column].max()
+            
 
             # Generate regular date range for each group
             date_range = pd.date_range(start=min_date, end=max_date, freq=freq)

--- a/tests/test_pad_by_time.py
+++ b/tests/test_pad_by_time.py
@@ -82,7 +82,32 @@ def test_pad_by_time_grouped(test_dataframe):
     # Check if the result matches the expected DataFrame
     assert_frame_equal(padded_df, expected_df, check_dtype=False)
 
+def test_pad_by_time_grouped_end(test_dataframe):
+    # Create a grouped DataFrame for testing
+    #grouped_df = test_dataframe.copy()
+    grouped_df["group"] = ["A", "B","A", "B", "B", "A"]
+    #grouped_df = grouped_df.groupby("group")
 
+    # Apply pad_by_time to the grouped DataFrame
+    padded_df = (
+        grouped_df.groupby('group')
+        .pad_by_time(date_column="date", freq="D", end_date = '2022-01-06')
+    )
+
+    # Define the expected result for each group
+    expected_data = {
+        "date": ['2022-01-01','2022-01-02','2022-01-03','2022-01-04',\
+                '2022-01-05','2022-01-06','2022-01-02','2022-01-03',\
+                '2022-01-04','2022-01-05','2022-01-06'],
+                
+        "group": ["A", "A", "A", "A", "A","A",'B','B','B','B','B'],
+        "value": [1, np.nan, 3, np.nan,np.nan, 6,2,np.nan,4, 5, np.nan],
+        
+    }
+    expected_df = pd.DataFrame(expected_data)
+    expected_df['date'] = pd.to_datetime(expected_df['date'])
+    # Check if the result matches the expected DataFrame
+    assert_frame_equal(padded_df, expected_df, check_dtype=False)
 
 # def test_pad_by_time_auto_freq(test_dataframe):
 #     # Apply pad_by_time with auto frequency detection


### PR DESCRIPTION
Addressed issue #37.
Pad By Time Grouped - End Behavior 

This fix adds an input variable:global_group_max which allows users to select if they want to use the global max or local max when deciding the end time to use for padding.