### PR TITLE
Updated parameter to start_date and end_date

### DIFF
--- a/src/timetk/core/pad.py
+++ b/src/timetk/core/pad.py
@@ -151,7 +151,7 @@ def pad_by_time(
         for idx, group in groups.iterrows():
             mask = (df[group_names] == group).all(axis=1)
             group_df = df[mask]
-            
+             
             # if freq == 'auto':
             #     freq = get_pandas_frequency(group_df[date_column], force_regular=force_regular)
             

--- a/tests/test_pad_by_time.py
+++ b/tests/test_pad_by_time.py
@@ -52,7 +52,7 @@ data2 = {
 df2 = pd.DataFrame(data2)
 grouped_df = df2.copy()
 grouped_df["group"] = ["A", "B","A", "B", "B", "A"]
-
+ 
 
 # Apply pad_by_time to the grouped DataFrame
 def test_pad_by_time_grouped(test_dataframe):


### PR DESCRIPTION
New behavior to mimic to R package.

    start_date : str, optional
        Specifies the start of the padded series.  If NULL, it will use the lowest value of the input variable. In the case of groups, it will use the lowest value by group.
        
    end_date  : str, optional;
        Specifies the end of the padded series.  If NULL, it will use the highest value of the input variable.  In the case of groups, it will use the highest value by group.
    
    
Also updated the test_pad_by_time file to account for changes