### PR TITLE
Error in plot_timeseries with engine = Matplotlib #54 - sets default …

### DIFF
--- a/src/timetk/plot/plot_timeseries.py
+++ b/src/timetk/plot/plot_timeseries.py
@@ -375,6 +375,7 @@ def plot_timeseries(
         )
         
         if engine == 'matplotlib':
+            fig = fig + theme(figure_size=(8, 6)) # setting default figure size to prevent matplotlib sizing error
             fig = fig.draw()
         
     elif engine == 'plotly':


### PR DESCRIPTION
Error in plot_timeseries with engine = Matplotlib #54
Updated code for when using engine=matplotlib, a  default plot size of (8,6) will be used to prevent the "Image Size" error