### PR TITLE
Error in plot_timeseries with engine = Matplotlib #54 - Updated Defau…

### DIFF
--- a/src/timetk/plot/plot_timeseries.py
+++ b/src/timetk/plot/plot_timeseries.py
@@ -375,7 +375,18 @@ def plot_timeseries(
         )
         
         if engine == 'matplotlib':
+            if width == None:
+                width_size = 8
+            else: 
+                width_size = width
+
+            if height == None:
+                height_size = 6
+            else:
+                height_size = height
+            fig = fig + theme(figure_size=(width_size, height_size)) # setting default figure size to prevent matplotlib sizing error
             fig = fig.draw()
+
         
     elif engine == 'plotly':
         


### PR DESCRIPTION
Error in plot_timeseries with engine = Matplotlib #54
Updated default plot size behavior when width and/or height are left null to prevent plot size error