### PR TITLE
Fix: enhance error handling for use_independent_variables

### DIFF
--- a/src/pytimetk/core/expanding.py
+++ b/src/pytimetk/core/expanding.py
@@ -181,14 +181,11 @@ def augment_expanding(
                         try:   
                             group_df[new_column_name] = group_df[value_col].expanding(min_periods=min_periods, **kwargs).apply(func, raw=True)
                         except Exception as e:
-                            specific_error_msg = "only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`) and integer or boolean arrays are valid indices"
-                            if str(e) == specific_error_msg:
                                 try: # try independent variables incase user mistakenly did not set to True
                                     group_df[new_column_name] = expanding_apply(func, group_df, min_periods=min_periods)
                                 except:
-                                    raise
-                            else:
-                                raise
+                                    raise e
+                                
                 elif isinstance(func, str):
                     new_column_name = f"{value_col}_expanding_{func}"
                     

--- a/src/pytimetk/core/rolling.py
+++ b/src/pytimetk/core/rolling.py
@@ -253,9 +253,13 @@ def augment_rolling(
                         if use_independent_variables:                           
                             group_df[new_column_name] = rolling_apply_2(func, group_df, window_size, min_periods=min_periods, center=center)
                         else:
-                            # group_df[new_column_name] = rolling_apply(func, group_df[value_col])
-                            group_df[new_column_name] = group_df[value_col].rolling(window=window_size, min_periods=min_periods,center=center, **kwargs).apply(func, raw=True)
-                    
+                            try:   
+                                group_df[new_column_name] = group_df[value_col].rolling(window=window_size, min_periods=min_periods, center=center, **kwargs).apply(func, raw=True)
+                            except Exception as e:
+                                    try: # try independent variables incase user mistakenly did not set to True
+                                        group_df[new_column_name] = rolling_apply_2(func, group_df, window_size, min_periods=min_periods, center=center)
+                                    except:
+                                        raise e
                             
                     elif isinstance(func, str):
                         new_column_name = f"{value_col}_rolling_{func}_win_{window_size}"


### PR DESCRIPTION
If an error is thrown when using the pandas rolling/expanding function it will try the rolling/expanding_apply function.

This handles the case when a user supplies a custom window function but forgets to set user_independent_variables to True.