### PR TITLE
[Refactor]:  specifying features for dataframe and grouped dataframes

### DIFF
--- a/tests/test_ts_features.py
+++ b/tests/test_ts_features.py
@@ -1,0 +1,143 @@
+import pytest
+import pandas as pd
+import pytimetk as tk
+
+from tsfeatures import (
+    acf_features, series_length, hurst
+)
+
+@pytest.fixture
+def data_frame_to_test()-> pd.DataFrame:
+    '''The function  creates a pandas DataFrame with date and value
+    for tests.
+    
+    Returns
+    -------
+    pd.DataFrame
+        A pandas DataFrame.    
+    '''
+    data = pd.DataFrame({
+        'date': pd.date_range(start='1/1/2020', periods=10),
+        'value': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    })
+
+    return data
+
+@pytest.fixture
+def grouped_data_frame_to_test() -> pd.DataFrame:
+    '''The function loads m4_daily pandas DataFrame to make the 
+    tests with grouped dataframe.
+    
+    Returns
+    -------
+    pd.DataFrame
+        A pandas DataFrame.    
+    '''
+    data = tk.load_dataset('m4_daily', parse_dates = ['date'])
+
+    return data
+
+def test_ts_features_dataframe_with_all_features(data_frame_to_test):
+    # Load data frame
+    df = data_frame_to_test
+
+    # Call the ts_features function
+    result = tk.ts_features(df, 'date', 'value')
+
+    # Assert the result is a Pandas DataFrame
+    assert isinstance(result, pd.DataFrame)
+
+    # Assert the result has the correct columns
+    expected_columns = [
+        'hurst', 'series_length',
+        'unitroot_pp', 'unitroot_kpss',
+        'stability', 'nperiods', 'seasonal_period', 'nonlinearity',
+        'lumpiness', 'alpha', 'beta', 'flat_spots', 'entropy',	
+        'crossing_points', 'x_acf1'
+    ]
+
+    assert result.columns.tolist() == expected_columns
+
+    # Assert if was generated one row
+    assert result.shape[0] == 1
+
+def test_ts_features_dataframe_specifying_features(data_frame_to_test):
+    # Load data frame
+    df = data_frame_to_test
+
+    # Call the ts_features function
+    result = tk.ts_features(df, 'date', 'value',
+                            features=[hurst, series_length])
+
+    # Assert the result is a Pandas DataFrame
+    assert isinstance(result, pd.DataFrame)
+
+    # Assert the result has the correct columns
+    expected_columns = [
+        'series_length', 'hurst'
+    ]
+
+    assert result.columns.tolist() == expected_columns
+
+    # Assert if was generated one row
+    assert result.shape[0] == 1
+
+def test_ts_features_grouped_dataframe_with_all_features(grouped_data_frame_to_test):
+    # Load data frame with groups
+    df = grouped_data_frame_to_test
+
+    # Call the ts_features function
+    result = df.groupby('id') \
+        .ts_features(    
+            date_column  = 'date', 
+            value_column = 'value'
+        )
+
+    # Assert the result is a Pandas DataFrame
+    assert isinstance(result, pd.DataFrame)
+
+    # Assert the result has the correct columns
+    expected_columns = ['id', 'hurst', 'series_length', 'unitroot_pp', 'unitroot_kpss',
+       'hw_alpha', 'hw_beta', 'hw_gamma', 'stability', 'nperiods',
+       'seasonal_period', 'trend', 'spike', 'linearity', 'curvature', 'e_acf1',
+       'e_acf10', 'x_pacf5', 'diff1x_pacf5', 'diff2x_pacf5', 'nonlinearity',
+       'lumpiness', 'alpha', 'beta', 'arch_acf', 'garch_acf', 'arch_r2',
+       'garch_r2', 'flat_spots', 'entropy', 'crossing_points', 'arch_lm',
+       'x_acf1', 'x_acf10', 'diff1_acf1', 'diff1_acf10', 'diff2_acf1',
+       'diff2_acf10'
+       ]
+
+    assert result.columns.tolist() == expected_columns
+
+    # Assert if was generated four rows
+    assert result.shape[0] == 4
+
+def test_ts_features_grouped_dataframe_specifying_features(grouped_data_frame_to_test):
+    # Load data frame with groups
+    df = grouped_data_frame_to_test
+
+    # Call the ts_features function
+    result = df.groupby('id') \
+        .ts_features(    
+            date_column  = 'date', 
+            value_column = 'value',
+            features     = [acf_features, hurst, series_length]
+        )
+
+    # Assert the result is a Pandas DataFrame
+    assert isinstance(result, pd.DataFrame)
+
+    # Assert the result has the correct columns
+    expected_columns = [
+        'id', 'series_length', 'hurst',
+        'x_acf1', 'x_acf10', 'diff1_acf1', 'diff1_acf10',
+        'diff2_acf1', 'diff2_acf10'
+    ]
+
+    assert result.columns.tolist() == expected_columns
+
+    # Assert if was generated four rows
+    assert result.shape[0] == 4
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
I made a few refactors here:

* I moved the variable `group_names` to prevent overwriting.
* Instead of using `data = data.copy()`, I now use `df = data.obj.copy()` because I need to verify at the end of the code whether `data` is a data frame or a grouped data frame.
* I created `construct_df` for non-grouped data frames.
* I applied the `ts_features` function to both data frames and grouped data frames.
* I included  `dropna` in the result of `ts_features`. These columns are not applied to non-grouped data frames.
* I included some tests.