### PR TITLE
Fixed augment_rolling guide center False typo branch

### DIFF
--- a/docs/guides/05_augmenting.qmd
+++ b/docs/guides/05_augmenting.qmd
@@ -219,7 +219,7 @@ df \
 		value_column = 'value',
 		window       = 3,
 		window_func  = 'mean',
-		center       = True
+		center       = False
 	)
 ```
 


### PR DESCRIPTION
Center = True tab and Center = False tab both had the code
Center = True. 

Fixed the typo on the False tab.