### PR TITLE
[fix]: Use `polars.group_by` when the input is `pandas.groupby`

### DIFF
--- a/src/pytimetk/core/lags.py
+++ b/src/pytimetk/core/lags.py
@@ -207,7 +207,12 @@ def _augment_lags_polars(
 
     # Select the columns
     df = pl.DataFrame(pandas_df)
-    out_df = df.select(selected_columns)
+    if isinstance(data, pd.core.groupby.generic.DataFrameGroupBy):
+        out_df = df.group_by(data.grouper.names, maintain_order=True).agg(selected_columns)
+        out_df = out_df.explode(out_df.columns[1:])
+        out_df = out_df.drop(data.grouper.names)
+    else: # a dataframe
+        out_df = df.select(selected_columns)
 
     # Concatenate the DataFrames horizontally
     df = pl.concat([df, out_df], how="horizontal").to_pandas()


### PR DESCRIPTION
I used `polars.group_by` when the data argument is a `pandas.groupby`.

Notes:

* The parameter `maintain_order` is necessary to maintain the order of data groups, and it will be used to run `pl.concat` correctly.
* Polars groups the results in the same row, so I needed to explode.
* I dropped the first col because `df` already has the group column.
