### PR TITLE
pandas pad 

### DIFF
--- a/src/pytimetk/core/pad.py
+++ b/src/pytimetk/core/pad.py
@@ -144,6 +144,15 @@ def pad_by_time(
         
         padded_df.sort_values(by=[date_column], inplace=True)
         padded_df.reset_index(drop=True, inplace=True)
+
+        col_name = padded_df.columns[padded_df.nunique() == 1]
+        if not col_name.empty:
+            col_name = col_name[0]
+        else:
+            col_name = None
+
+        if col_name is not None:
+            padded_df = padded_df.assign(**{f'{col_name}': padded_df[col_name].ffill()})
         
         return padded_df
     


### PR DESCRIPTION
Quick there was not alignment between the singular series/dataframe and the group based pad. In the singular instance there was a need for further wrangling to forward fill names, while for the group based pad this was taken care of. 

I used a simple trick to find the column with 0 variance, to isolate in the event that this column exists and automatically forward fill this. Now there is alignment for this pandas version. 