### PR TITLE
Augment fourier - dataframes only

### DIFF
--- a/src/pytimetk/core/fourier.py
+++ b/src/pytimetk/core/fourier.py
@@ -104,7 +104,7 @@ def augment_fourier_v2(
         for type_val in ("sin", "cos"):
             for K_val in range(1, max_order + 1):
                 for period_val in range(1, num_periods + 1):
-                    df[f'fourier_{type_val}_{K_val}_{period_val}'] = fourier_vec(df['radians'], period_val, type_val, scale_factor, K_val)
+                    df[f'{date_column}_{type_val}_{K_val}_{period_val}'] = fourier_vec(df['radians'], period_val, type_val, scale_factor, K_val)
 
 
     # GROUPED EXTENSION - If data is a GroupBy object, add Fourier transforms by group

--- a/src/pytimetk/core/fourier.py
+++ b/src/pytimetk/core/fourier.py
@@ -7,10 +7,12 @@ from pytimetk.core.ts_summary import ts_summary
 
 
 
-def fourier_vec(x, period, type: str, scale_factor, K = 1):
+def fourier_vec(x: pd.Series, period, type: str, scale_factor, K = 1):
     """
     type = sin or cos
     """
+
+    x = x.astype(int)
 
     if scale_factor == 0:
         raise ValueError('Time difference between observations is zero. Try arranging data to have a positive time difference between observations. If working with time series groups, arrange by groups first, then date.')
@@ -25,20 +27,95 @@ def calc_fourier(x, period, type: str, K = 1):
     return np.sin(2 * np.pi * term * x) if type == "sin" else np.cos(2 * np.pi * term * x)
 
 
-def date_to_seq_scale_factor(data: pd.DataFrame, date_var: str) -> Union[None, float]:
-    return ts_summary(data[date_var])['diff_median']
+def date_to_seq_scale_factor(data: pd.DataFrame, date_var: str) -> pd.Series:
+    return ts_summary(data, date_column=date_var)['diff_median']
 
 
-def tk_augment_fourier_dataframe(data: pd.DataFrame, date_var: str, periods=1, K=1, names="auto"):
+@pf.register_dataframe_method
+def augment_fourier_v2(
+    data: Union[pd.DataFrame, pd.core.groupby.generic.DataFrameGroupBy], 
+    date_column: str,
+    num_periods: int = 1,
+    max_order: int = 1
+) -> pd.DataFrame:
+    """
+    Adds Fourier transforms to a Pandas DataFrame or DataFrameGroupBy object.
+
+    The `augment_fourier` function takes a Pandas DataFrame or GroupBy object, a date column, a value column or list of value columns, the number of periods for the Fourier series, and the maximum Fourier order, and adds Fourier-transformed columns to the DataFrame.
+
+    Parameters
+    ----------
+    data : pd.DataFrame or pd.core.groupby.generic.DataFrameGroupBy
+        The `data` parameter is the input DataFrame or DataFrameGroupBy object that you want to add Fourier-transformed columns to.
+    date_column : str
+        The `date_column` parameter is a string that specifies the name of the column in the DataFrame that contains the dates. This column will be used to compute the Fourier transforms.
+    value_column : str or list
+        The `value_column` parameter is the column(s) in the DataFrame that you want to apply Fourier transforms to. It can be either a single column name (string) or a list of column names.
+    num_periods : int, optional
+        The `num_periods` parameter specifies the number of periods for the Fourier series. Default is 1.
+    max_order : int, optional
+        The `max_order` parameter specifies the maximum Fourier order to calculate. Default is 1.
+
+    Returns
+    -------
+    pd.DataFrame
+        A Pandas DataFrame with Fourier-transformed columns added to it.
     
-    df = data.copy()
+    Examples
+    --------
+    ```{python}
+    import pandas as pd
+    import pytimetk as tk
 
-    scale_factor = date_to_seq_scale_factor(data, date_var)
+    df = tk.load_dataset('m4_daily', parse_dates=['date'])
     
-    for type_val in ("sin", "cos"):
-        for K_val in range(1, K + 1):
-            for period_val in range(1, periods + 1):
-                df[f'{date_var}_fourier_{type_val}_{period_val}_{K}'] = fourier_vec(date_var, period_val, type_val, scale_factor, K_val)
+    # Add Fourier transforms for a single column
+    fourier_df = (
+        df
+            .groupby('id')
+            .augment_fourier(
+                date_column='date',
+                value_column='value',
+                num_periods=7,
+                max_order=1
+            )
+    )
+    fourier_df.head()
+    ```
+
+    """
+
+    # Common checks
+    check_dataframe_or_groupby(data)
+    check_date_column(data, date_column)
+
+    # DATAFRAME EXTENSION - If data is a Pandas DataFrame, extend with Fourier transforms
+    if isinstance(data, pd.DataFrame):
+
+        df = data.copy()
+        df.sort_values(by=[date_column], inplace=True)
+
+        # Calculate radians for the date values
+        min_date = df[date_column].min()
+        df['radians'] = 2 * np.pi * (df[date_column] - min_date).dt.total_seconds() / (24 * 3600)
+
+        scale_factor = date_to_seq_scale_factor(df, date_column).iloc[0].total_seconds() / (24 * 3600)
+        
+        for type_val in ("sin", "cos"):
+            for K_val in range(1, max_order + 1):
+                for period_val in range(1, num_periods + 1):
+                    df[f'fourier_{type_val}_{K_val}_{period_val}'] = fourier_vec(df['radians'], period_val, type_val, scale_factor, K_val)
+
+
+    # GROUPED EXTENSION - If data is a GroupBy object, add Fourier transforms by group
+    if isinstance(data, pd.core.groupby.generic.DataFrameGroupBy):
+
+        raise NotImplementedError()
+
+    # Drop the temporary 'radians' column
+    df.drop(columns=['radians'], inplace=True)
+
+    return df
 
 
 @pf.register_dataframe_method
@@ -107,13 +184,13 @@ def augment_fourier(
     # DATAFRAME EXTENSION - If data is a Pandas DataFrame, extend with Fourier transforms
     if isinstance(data, pd.DataFrame):
 
-        df = data.copy()
-
-        df.sort_values(by=[date_column], inplace=True)
-        
         # Calculate radians for the date values
         min_date = data[date_column].min()
         data['radians'] = 2 * np.pi * (data[date_column] - min_date).dt.total_seconds() / (24 * 3600)
+
+        df = data.copy()
+
+        df.sort_values(by=[date_column], inplace=True)
 
         for col in value_column:
             for order in range(1, max_order + 1):
@@ -153,3 +230,4 @@ def augment_fourier(
 
 # Monkey patch the method to pandas groupby objects
 pd.core.groupby.generic.DataFrameGroupBy.augment_fourier = augment_fourier
+pd.core.groupby.generic.DataFrameGroupBy.augment_fourier_v2 = augment_fourier_v2

--- a/src/pytimetk/core/fourier.py
+++ b/src/pytimetk/core/fourier.py
@@ -6,18 +6,6 @@ from pytimetk.utils.checks import check_dataframe_or_groupby, check_date_column,
 from pytimetk.core.ts_summary import ts_summary
 
 
-
-def fourier_vec(x: pd.Series, period, type: str, K = 1):
-    """
-    type = sin or cos
-    """
-
-    # apply scaling
-    x_scaled = x
-
-    return calc_fourier(x = x_scaled, period = period, type = type, K = K)
-
-
 def calc_fourier(x, period, type: str, K = 1): 
     term = K / period
     return np.sin(2 * np.pi * term * x) if type == "sin" else np.cos(2 * np.pi * term * x)


### PR DESCRIPTION
Hi, 
Let me know your thoughts about this implementation. 
I think it is what was expected. With order 1 (k=1) I got the same results than the current function. 
I only implemented the function for the DataFrames, and if it is validated it will be straightforward to do the same for the groups. 
I would also like to replace those for loops, but for the moment I was more interested in the correctness of the results :)

fix  #22 
NB this is a working version. I implemented my fix in a _v2 function so that the other function still works :)