### PR TITLE
[feature]: include polars engine on `get_seasonal_frequency`

### DIFF
--- a/tests/test_get_seasonal_frequency.py
+++ b/tests/test_get_seasonal_frequency.py
@@ -1,0 +1,30 @@
+import pandas as pd
+import pytimetk as tk
+import pytest
+
+@pytest.mark.parametrize('freq, regular, engine, expected',[
+    ('D', False, 'pandas', '1W'), ('D', False, 'polars', '1W'),
+    ('D', True,  'pandas', '1W'), ('D', True,  'polars', '1W'),
+    ('W', False, 'pandas', '1Q'), ('W', False, 'polars', '1Q'),
+    ('W', True,  'pandas', '1Q'), ('W', True,  'polars', '1Q'),
+    ('M', False, 'pandas', '1Y'), ('M', False, 'polars', '1Y'),
+    ('M', True,  'pandas', '1Y'), ('M', True,  'polars', '1Y'),
+    ('Q', False, 'pandas', '1Y'), ('Q', False, 'polars', '1Y'),
+    ('Q', True,  'pandas', '1Y'), ('Q', True,  'polars', '1Y'),
+    ('Y', False, 'pandas', '5Y'), ('Y', False, 'polars', '5Y'),
+    ('Y', True,  'pandas', '5Y'), ('Y', True,  'polars', '5Y'),
+])
+def test_correct_seasonal_inference(freq, regular, engine, expected):
+    """
+    This function tests if the inferred seasonal frequency of 
+    a datetime series is correct.    
+    """
+
+    # Create a sample datetime series using freq parameter
+    dates = pd.date_range(start='2021-01-01', end='2024-01-01', freq = freq)
+
+    # Invoke the get_seasonal_frequency function
+    result = tk.get_seasonal_frequency(dates, force_regular = regular, engine = engine)
+
+    # Check inferred frequency
+    assert result == expected


### PR DESCRIPTION
In this PR I have:

* included `engine` parameter on `get_seasonal_frequency`
* fixed `time_scale_template` to return `median_unit` as the index when using polars. Now `time_scale_template` returns the same result when using polars or pandas
* added `force_regular` to `get_frequency_summary`
* included the tests