### PR TITLE
future frame forward fill internal

### DIFF
--- a/src/pytimetk/core/future.py
+++ b/src/pytimetk/core/future.py
@@ -115,7 +115,6 @@ def future_frame(
                 date_column = 'date', 
                 length_out  = 12
             )
-            .assign(id = lambda x: x['id'].ffill())
     )
     extended_df
     ```
@@ -241,7 +240,16 @@ def _future_frame_pandas(
             extended_df = pd.concat([data, new_rows], axis=0, ignore_index=True)
         else:
             extended_df = new_rows
-        
+
+        col_name = extended_df.columns[extended_df.nunique() == 1]
+        if not col_name.empty:
+            col_name = col_name[0]
+        else:
+            col_name = None
+
+        if col_name is not None:
+            extended_df = extended_df.assign(**{f'{col_name}': extended_df[col_name].ffill()})
+
         return extended_df  
     
     # If the data is grouped

--- a/src/pytimetk/feature_engineering/lags.py
+++ b/src/pytimetk/feature_engineering/lags.py
@@ -85,7 +85,7 @@ def augment_lags(
     )
     lagged_df_single
     ```
-
+    ```{python}
     # Example 2 - Add a single lagged value of 2 for each GroupBy object, polars engine
     lagged_df = (
         df 

--- a/src/pytimetk/feature_engineering/lags.py
+++ b/src/pytimetk/feature_engineering/lags.py
@@ -84,6 +84,7 @@ def augment_lags(
             )
     )
     lagged_df_single
+    ```
 
     # Example 2 - Add a single lagged value of 2 for each GroupBy object, polars engine
     lagged_df = (

--- a/src/pytimetk/feature_engineering/leads.py
+++ b/src/pytimetk/feature_engineering/leads.py
@@ -83,7 +83,8 @@ def augment_leads(
             )
     )
     lead_df_single
-
+    ```
+    ```{python}
     # Example 2 - Add a single lead value of 2 for each GroupBy object, polars engine
     lead_df = (
         df 


### PR DESCRIPTION
future frame on single series behavior was different than the groupby in the event that there is just a singular dataframe as opposed to a groupby so the name for a given id if present required the use of a lambda to forward fill. I have added to the function to do this automatically internally in the case there is an id column so it eliminates the need for lambda after the fact. I have updated the docstring accordingly as well.