### PR TITLE
[feature]: Include polars engine on `get_trend_frequency()`

### DIFF
--- a/src/pytimetk/core/frequency.py
+++ b/src/pytimetk/core/frequency.py
@@ -420,7 +420,12 @@ def get_seasonal_frequency(
     return _period
     
 @pf.register_series_method
-def get_trend_frequency(idx: Union[pd.Series, pd.DatetimeIndex], force_regular: bool = False, numeric: bool = False):
+def get_trend_frequency(
+    idx: Union[pd.Series, pd.DatetimeIndex],
+    force_regular: bool = False,
+    numeric: bool = False,
+    engine: str = 'pandas'
+) -> str:
     '''
     The `get_trend_frequency` function returns the trend period of a given time 
     series or datetime index.
@@ -442,6 +447,15 @@ def get_trend_frequency(idx: Union[pd.Series, pd.DatetimeIndex], force_regular: 
         If `numeric` is set to `True`, the output will be a numeric representation 
         of the trend period. If `numeric` is set to `False` (default), the output 
         will
+    engine : str, optional
+        The `engine` parameter is used to specify the engine to use for 
+        generating a date summary. It can be either "pandas" or "polars". 
+        
+        - The default value is "pandas".
+        
+        - When "polars", the function will internally use the `polars` library 
+          for generating the time scale information. 
+    
     
     Returns
     -------
@@ -460,8 +474,7 @@ def get_trend_frequency(idx: Union[pd.Series, pd.DatetimeIndex], force_regular: 
     
     dates = pd.date_range(start='2021-01-01', end='2024-01-01', freq='MS')
     
-    tk.get_trend_frequency(dates)
-    
+    tk.get_trend_frequency(dates)    
     ```
     '''
     
@@ -471,7 +484,7 @@ def get_trend_frequency(idx: Union[pd.Series, pd.DatetimeIndex], force_regular: 
     if isinstance(idx, pd.DatetimeIndex):
         idx = pd.Series(idx, name="idx")
     
-    summary_freq = get_frequency_summary(idx)
+    summary_freq = get_frequency_summary(idx, force_regular = force_regular)
     
     scale = summary_freq['freq_median_scale'].values[0]
     unit = summary_freq['freq_median_unit'].values[0]
@@ -486,7 +499,7 @@ def get_trend_frequency(idx: Union[pd.Series, pd.DatetimeIndex], force_regular: 
                 unit = "M"  
     
     def _lookup_trend_period(unit):
-        return time_scale_template(wide_format=True)[unit]['trend_period']
+        return time_scale_template(wide_format=True, engine = engine)[unit]['trend_period']
     
     _period = _lookup_trend_period(unit)
     

--- a/tests/test_get_trend_frequency.py
+++ b/tests/test_get_trend_frequency.py
@@ -1,0 +1,30 @@
+import pandas as pd
+import pytimetk as tk
+import pytest
+
+@pytest.mark.parametrize('freq, regular, engine, expected',[
+    ('D', False, 'pandas', '3M' ), ('D', False, 'polars', '3M' ),
+    ('D', True,  'pandas', '3M' ), ('D', True,  'polars', '3M' ),
+    ('W', False, 'pandas', '1Y' ), ('W', False, 'polars', '1Y' ),
+    ('W', True,  'pandas', '1Y' ), ('W', True,  'polars', '1Y' ),
+    ('M', False, 'pandas', '5Y' ), ('M', False, 'polars', '5Y' ),
+    ('M', True,  'pandas', '5Y' ), ('M', True,  'polars', '5Y' ),
+    ('Q', False, 'pandas', '10Y'), ('Q', False, 'polars', '10Y'),
+    ('Q', True,  'pandas', '10Y'), ('Q', True,  'polars', '10Y'),
+    ('Y', False, 'pandas', '30Y'), ('Y', False, 'polars', '30Y'),
+    ('Y', True,  'pandas', '30Y'), ('Y', True,  'polars', '30Y'),
+])
+def test_correct_trend_inference(freq, regular, engine, expected):
+    """
+    This function tests if the inferred trend frequency of 
+    a datetime series is correct.    
+    """
+
+    # Create a sample datetime series using freq parameter
+    dates = pd.date_range(start='2021-01-01', end='2024-01-01', freq = freq)
+
+    # Invoke the get_trend_frequency function
+    result = tk.get_trend_frequency(dates, force_regular = regular, engine = engine)
+
+    # Check inferred frequency
+    assert result == expected


### PR DESCRIPTION
In this PR I have:

* included engine parameter on `get_trend_frequency()`
* added `force_regular` parameter to `get_frequency_summary()`
* included the tests