### PR TITLE
Changed my email on pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ maintainers = [
     "Matt Dancho <mdancho@business-science.io>",
     "Justin B. Kurland <justin.b.kurland@gmail.com>",
     "Jeff Tackes <tackes@gmail.com>",
-    "Samuel Macêdo <dmmada@gmail.com>",
+    "Samuel Macêdo <svm.macedo@gmail.com>",
     "Lucas Okwudishu <clfo2014@gmail.com>",
     "Alex Riggio <alexmriggio@gmail.com>",
 ]


### PR DESCRIPTION
I changed my email on pyproject.toml because dmmada is my personal email. The svm.macedo is what I use on github.