### PR TITLE
add polars backend to get_frequency_summary - first draft

### DIFF
--- a/src/pytimetk/utils/checks.py
+++ b/src/pytimetk/utils/checks.py
@@ -54,6 +54,11 @@ def check_dataframe_or_groupby_polars(data: Union[pl.DataFrame, pl.dataframe.gro
     ], error_str='`data` is not a Polars DataFrame or GroupBy object.')
 
 
+def check_series_polars(data: pl.Series) -> None:
+    check_data_type(data, authorized_dtypes = [pl.Series], 
+                    error_str='Expected `data` to be a Polars Series.')
+
+
 def check_date_column(data: Union[pd.DataFrame, pd.core.groupby.generic.DataFrameGroupBy], date_column: str) -> None:
     
     if isinstance(data, pd.core.groupby.generic.DataFrameGroupBy):


### PR DESCRIPTION
Here is a first draft. 

It is working as is but I have two concerns: 

_get_pandas_frequency is difficult to convert because there is currently no idx.inferred_freq equivalent in polars.
The only solution I can think of is to write an equivalent of inferred_freq pandas implementation, but I am not sure if it is worth the time.

I don't know what unit is expected for freq_median_timedelta. 
Again, there is no timedelta in polars so I create it from _freq_median_seconds and put the unit to seconds. 
But the output is probably not consistent with the pandas implementation then ? 

Linked to #77 
