### PR TITLE
docs: fix received spelling in docs

### DIFF
--- a/docs/getting-started/02_quick_start.qmd
+++ b/docs/getting-started/02_quick_start.qmd
@@ -31,7 +31,7 @@ First, `import pytimetk as tk`. This gets you access to the most important funct
 ::: {.callout-note collapse="false"}
 ## About the Bike Sales Sample Dataset
 
-This dataset contains "orderlines" for orders recieved. The `order_date` column contains timestamps. We can use this column to peform sales aggregations (e.g. total revenue).
+This dataset contains "orderlines" for orders received. The `order_date` column contains timestamps. We can use this column to peform sales aggregations (e.g. total revenue).
 :::
 
 ```{python}


### PR DESCRIPTION
Changes:
- `recieved` -> `received` in `docs/getting-started/02_quick_start.qmd` (1 occurrence(s), preserving capitalization where applicable)

Verification:
- Applied an exact spelling-only replacement against the current upstream base branch.
- Checked the repository is not archived or a fork.
- Checked open PR titles and my open PRs before opening this PR.
